### PR TITLE
fix CT regex https://github.com/nitely/nim-regex/issues/4

### DIFF
--- a/src/unicodedb/types.nim
+++ b/src/unicodedb/types.nim
@@ -21,10 +21,42 @@ proc unicodeTypes*(cp: Rune): int {.inline.} =
   ## Return types for a given code point.
   ## Use `contains` to retrieve a single type
   assert cp.int <= 0x10FFFF
-  let
-    blockOffset = (typesOffsets[cp.int div blockSize]).int * blockSize
-    idx = typesIndices[blockOffset + cp.int mod blockSize]
-  result = typesData[idx]
+  when nimvm:
+    #[
+    ugly workaround for https://github.com/nitely/nim-regex/issues/4
+    typesOffsets.len = 8704
+    typesIndices.len = 31104 ; this gives a code size of ~93321 instructions
+    (3 instructions per array element), which doesn't fit in `int16.high`
+    required in vmgen (0x7fff)
+    ]#
+    const N = typesIndices.len
+    const N2 = N div 3
+    const t0 = typesIndices[0 ..< N2]
+    const t1 = typesIndices[N2 ..< 2*N2]
+    const t2 = typesIndices[2*N2 ..< N]
+
+    proc getTypeIndex(sub: static int, ind: int): auto =
+      when sub == 0: return t0[ind]
+      elif sub == 1: return t1[ind]
+      else: return t2[ind]
+    let blockOffset = (typesOffsets[cp.int div blockSize]).int * blockSize
+    block:
+      let ind = blockOffset + cp.int mod blockSize
+      let ind2 = ind div N2
+      let j = ind mod N2
+      var idx = 0'i8
+      case ind2
+      of 0: idx = getTypeIndex(0, j)
+      of 1: idx = getTypeIndex(1, j)
+      of 2: idx = getTypeIndex(2, j)
+      else: assert false
+      result = typesData[idx]
+
+  else:
+    block:
+      let blockOffset = (typesOffsets[cp.int div blockSize]).int * blockSize
+      let idx = typesIndices[blockOffset + cp.int mod blockSize]
+      result = typesData[idx]
 
 proc contains*(ut: int, utm: UnicodeTypeMask): bool =
   ## Check if the given type mask is

--- a/src/unicodedb/types.nim
+++ b/src/unicodedb/types.nim
@@ -35,7 +35,7 @@ proc unicodeTypes*(cp: Rune): int {.inline.} =
     const t1 = typesIndices[N2 ..< 2*N2]
     const t2 = typesIndices[2*N2 ..< N]
 
-    proc getTypeIndex(sub: static int, ind: int): auto =
+    proc getTypeIndex(sub: static[int], ind: int): auto =
       when sub == 0: return t0[ind]
       elif sub == 1: return t1[ind]
       else: return t2[ind]


### PR DESCRIPTION
/cc @nitely please don't forget to create new git tag for both nim-regex and nim-unicodedb after merging!

* fixes CT regex https://github.com/nitely/nim-regex/issues/4
this is an ugly hack but it works; i was hoping something like https://github.com/nim-lang/Nim/pull/11579 could've been used instead but i didn't see how to make it work as the assumption `-0x7fff < diff and diff < 0x7fff` seems rather deeply rooted in vmgen

## note
CI fails for 0.18.0 (works for 0.19); although i could try to make it work for 0.18, how about dropping support for 0.18 (quite old now) and adding a CI for 0.20 instead? 
https://travis-ci.org/nitely/nim-unicodedb/jobs/553541005
```
/usr/src/app/src/unicodedb/types.nim(38, 28) Error: type expected
```