### PR TITLE
Bump to 0.11.2

### DIFF
--- a/unicodedb.nimble
+++ b/unicodedb.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version = "0.11.1"
+version = "0.11.2"
 author = "Esteban Castro Borsani (@nitely)"
 description = "Unicode Character Database (UCD) access for Nim"
 license = "MIT"


### PR DESCRIPTION
Currently, cannot install v0.11.2.

```
 Installing unicodedb@>= 0.11.2
Downloading https://github.com/nitely/nim-unicodedb using git
       Tip: 8 messages have been suppressed, use --verbose to show them.
     Error: Downloaded package's version does not satisfy requested version range: wanted >= 0.11.2 got 0.11.1.
```

Bump unicodedb to 0.11.2.